### PR TITLE
uncomment line to require custom null-ls settings

### DIFF
--- a/plugins.lua
+++ b/plugins.lua
@@ -39,7 +39,7 @@ local plugins = {
     "jose-elias-alvarez/null-ls.nvim",
     event = "VeryLazy",
     opts = function()
-      --return require "custom.configs.null-ls"
+      return require "custom.configs.null-ls"
     end,
   },
   {


### PR DESCRIPTION
Thank  you for your config and the nice videos. I noticed that language formatting wasn't working and saw that the relevant line for null-ls is commented in your config.