### PR TITLE
null-ls.nvim is no longer being maintained: Switching to new community-forked

### DIFF
--- a/plugins.lua
+++ b/plugins.lua
@@ -36,7 +36,7 @@ local plugins = {
     end
   },
   {
-    "jose-elias-alvarez/null-ls.nvim",
+    "nvimtools/none-ls.nvim",
     event = "VeryLazy",
     opts = function()
       return require "custom.configs.null-ls"


### PR DESCRIPTION
**null-ls.nvim is no longer being maintained.**
[Link to Issue #1621](https://github.com/jose-elias-alvarez/null-ls.nvim/issues/1621#issue-1795450982)

**Replacement Project: none-ls.nvim maintained by the community**
[none-ls.nvim](https://github.com/nvimtools/none-ls.nvim)

